### PR TITLE
Fix arm/arm64 support

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -60,7 +60,8 @@ install_version() {
     i386) architecture="386" ;;
     i686) architecture="386" ;;
     x86_64) architecture="amd64" ;;
-    arm) dpkg --print-architecture | grep -q "arm64" && architecture="arm64" || architecture="arm" ;;
+    armv*) architecture="arm" ;;
+    aarch64) architecture="arm64" ;;
   esac
 
   if [ "$install_type" != "version" ]; then


### PR DESCRIPTION
There is a bug in the installation script for arm/arm64 system-architectures where `uname -m` will never equal `arm` and an incorrect url is used to download the zip:
https://github.com/comdotlinux/asdf-loki-logcli/blob/master/lib/utils.bash#L63
```bash
    arm) dpkg --print-architecture | grep -q "arm64" && architecture="arm64" || architecture="arm" ;;
```
Instead, two switch cases can be added to accommodate these types:
```bash
   armv*) architecture="arm" ;;
   aarch64) architecture="arm64" ;;
```
```bash
# ---------------------------------------------------------- #

# Current BUG: 32-bit raspbian (arm)
$ uname -m
armv7l

$ asdf install loki-logcli latest
* Downloading loki-logcli release 2.3.0...
curl: (22) The requested URL returned error: 404
asdf-loki-logcli: Could not download https://github.com/grafana/loki/releases/download/v2.3.0/logcli-linux-.zip
asdf-loki-logcli: An error ocurred while installing loki-logcli 2.3.0.


# ---------------------------------------------------------- #


# FIXED: 32-bit Raspbian (arm)
$ asdf plugin remove loki-logcli

$ asdf plugin add loki-logcli https://github.com/mathew-fleisch/asdf-loki-logcli.git

$ asdf install loki-logcli latest
* Downloading loki-logcli release 2.3.0...
Archive:  /home/pi/.asdf/installs/loki-logcli/2.3.0/logcli-linux-arm.zip
  inflating: logcli-linux-arm
'logcli-linux-arm' -> '/home/pi/.asdf/installs/loki-logcli/2.3.0/bin/logcli'
loki-logcli 2.3.0 installation was successful!

$ asdf global loki-logcli latest

$ logcli --version
logcli, version  (branch: , revision: )
  build user:
  build date:
  go version:       go1.16.2
  platform:         linux/arm








# ---------------------------------------------------------- #









# Current BUG: 64-bit Ubuntu 20.04.2 LTS (arm64)
$ uname -m
aarch64

$ asdf install loki-logcli latest
* Downloading loki-logcli release 2.3.0...
curl: (22) The requested URL returned error: 404
asdf-loki-logcli: Could not download https://github.com/grafana/loki/releases/download/v2.3.0/logcli-linux-.zip
asdf-loki-logcli: An error ocurred while installing loki-logcli 2.3.0.


# ---------------------------------------------------------- #


# FIXED: 64-bit Ubuntu 20.04.2 LTS (arm64)
$ asdf plugin remove loki-logcli

$ asdf plugin add loki-logcli https://github.com/mathew-fleisch/asdf-loki-logcli.git

$ asdf install loki-logcli latest
* Downloading loki-logcli release 2.3.0...
Archive:  /opt/asdf/installs/loki-logcli/2.3.0/logcli-linux-arm64.zip
  inflating: logcli-linux-arm64
renamed 'logcli-linux-arm64' -> '/opt/asdf/installs/loki-logcli/2.3.0/bin/logcli'
loki-logcli 2.3.0 installation was successful!

$ asdf global loki-logcli latest

$ logcli --version
logcli, version  (branch: , revision: )
  build user:
  build date:
  go version:       go1.16.2
  platform:         linux/arm64
```