### PR TITLE
Fix arch detection

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -55,8 +55,8 @@ install_version() {
   local platform=$(uname | tr '[:upper:]' '[:lower:]')
 
   # Added architecture detection
-  local architecture=""
-  case $(uname -m) in
+  local architecture=$(uname -m)
+  case architecture in
     i386) architecture="386" ;;
     i686) architecture="386" ;;
     x86_64) architecture="amd64" ;;


### PR DESCRIPTION
I initialized the architecture variable to `uname -m`so that it doesn't end up blank if we fall outside of the cases.

On a arm64 mac, the follwoign URL would get generated before: https://github.com/grafana/loki/releases/download/v2.4.1/logcli-darwin-.zip and now it properly becomes https://github.com/grafana/loki/releases/download/v2.4.1/logcli-darwin-arm64.zip 